### PR TITLE
Latest xcode 11

### DIFF
--- a/src/ios/Pushy.swift
+++ b/src/ios/Pushy.swift
@@ -414,7 +414,7 @@ public class Pushy : NSObject {
         var pushPayload = userInfo;
         
         // Notification clicked?
-        if (application.applicationState == UIApplicationState.inactive) {
+        if (application.applicationState == UIApplication.State.inactive) {
             // Set flag for invoking click listener
             pushPayload["_pushyNotificationClicked"] = true;
         }


### PR DESCRIPTION
When I used xcode 11 with swift 5.0, error popup which tells us to use `UIApplication.State` intead of `UIApplicationState` which I fix. Well, to support older version of xcode, should I add or you some code which check if `UIApplication.State` or `UIApplicationState` exists?