### PR TITLE
adding an optional title to notifications, only used if sent

### DIFF
--- a/receiver/src/android/PushReceiver.java
+++ b/receiver/src/android/PushReceiver.java
@@ -24,6 +24,11 @@ public class PushReceiver extends BroadcastReceiver {
             notificationText = intent.getStringExtra("message");
         }
 
+        // Attempt to extract the notification title from the "title" property of the data payload (defaults to the app name if not present)
+        if (intent.getStringExtra("title") != null) {
+            notificationTitle = intent.getStringExtra("title");
+        }
+
         // Prepare a notification with vibration and sound
         Notification.Builder builder = new Notification.Builder(context)
                 .setAutoCancel(true)


### PR DESCRIPTION
Hey there,

I've just added a very simple check to see if the title has been sent as part of the data object, use it instead of the default appName, this gives a little bit more flexibility to anyone trying to send a notification to Android. 

Thanks!
Mo